### PR TITLE
Add Home button to navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 
   <!-- Sidebar Navigation -->
   <nav id="sidebar" aria-label="Project Navigation">
+    <h2><a id="homeLink" href="#">Home</a></h2>
     <h2>Projects</h2>
     <ul id="projectList">
       <!-- Project links appended here by JS -->

--- a/script.js
+++ b/script.js
@@ -2,6 +2,7 @@ const projectList = document.getElementById('projectList');
 const content = document.getElementById('content');
 const sidebar = document.getElementById('sidebar');
 const menuToggle = document.getElementById('menuToggle');
+const homeLink = document.getElementById('homeLink');
 
 let projectsData = [];
 let activeLink = null;  // No active project initially
@@ -75,6 +76,16 @@ function loadProject(project) {
 // Mobile menu toggle
 menuToggle.addEventListener('click', () => {
   sidebar.classList.toggle('open');
+});
+
+homeLink.addEventListener('click', e => {
+  e.preventDefault();
+  loadWelcome();
+  if (activeLink) {
+    activeLink.classList.remove('active');
+    activeLink = null;
+  }
+  closeSidebarOnMobile();
 });
 
 function closeSidebarOnMobile() {

--- a/style.css
+++ b/style.css
@@ -22,6 +22,11 @@ body {
     margin-bottom: 10px;
 }
 
+#sidebar h2 a {
+    text-decoration: none;
+    color: inherit;
+}
+
 #sidebar ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- add "Home" link above Projects in sidebar navigation
- support Home link to reset content and clear active project highlight
- ensure Home link inherits sidebar heading styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b22595cb88332848b30756228be61